### PR TITLE
Bump org.eclipse.jetty.version in /L5.1 Tests

### DIFF
--- a/L5.1 Tests/pom.xml
+++ b/L5.1 Tests/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0</version>
 
     <properties>
-        <org.eclipse.jetty.version>9.3.0.M1</org.eclipse.jetty.version>
+        <org.eclipse.jetty.version>11.0.0.beta3</org.eclipse.jetty.version>
         <org.apache.logging.log4j.version>2.2</org.apache.logging.log4j.version>
         <junit.version>4.11</junit.version>
         <org.mockito.version>1.8.4</org.mockito.version>


### PR DESCRIPTION
Bumps `org.eclipse.jetty.version` from 9.3.0.M1 to 11.0.0.beta3.

Updates `jetty-server` from 9.3.0.M1 to 11.0.0.beta3
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.3.0.M1...jetty-11.0.0.beta3)

Updates `jetty-webapp` from 9.3.0.M1 to 11.0.0.beta3
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.3.0.M1...jetty-11.0.0.beta3)