### PR TITLE
Bump log4j-api from 2.2 to 2.16.0 in /L5.1 Tests

### DIFF
--- a/L5.1 Tests/pom.xml
+++ b/L5.1 Tests/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <org.eclipse.jetty.version>9.3.0.M1</org.eclipse.jetty.version>
-        <org.apache.logging.log4j.version>2.2</org.apache.logging.log4j.version>
+        <org.apache.logging.log4j.version>2.16.0</org.apache.logging.log4j.version>
         <junit.version>4.11</junit.version>
         <org.mockito.version>1.8.4</org.mockito.version>
     </properties>


### PR DESCRIPTION
Bumps log4j-api from 2.2 to 2.16.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api dependency-type: direct:production ...