### PR TITLE
Bump org.apache.logging.log4j.version from 2.2 to 2.13.3 in /L5.1 Tests

### DIFF
--- a/L5.1 Tests/pom.xml
+++ b/L5.1 Tests/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <org.eclipse.jetty.version>9.3.0.M1</org.eclipse.jetty.version>
-        <org.apache.logging.log4j.version>2.2</org.apache.logging.log4j.version>
+        <org.apache.logging.log4j.version>2.13.3</org.apache.logging.log4j.version>
         <junit.version>4.11</junit.version>
         <org.mockito.version>1.8.4</org.mockito.version>
     </properties>


### PR DESCRIPTION
Bumps `org.apache.logging.log4j.version` from 2.2 to 2.13.3.

Updates `log4j-api` from 2.2 to 2.13.3

Updates `log4j-core` from 2.2 to 2.13.3